### PR TITLE
fix(gsd-4716): fixed broken debug log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ dump.rdb
 *.env.example
 *.env.local
 *.env.staging
+.elixir_ls

--- a/apps/explorer/lib/explorer/counters/helper.ex
+++ b/apps/explorer/lib/explorer/counters/helper.ex
@@ -20,7 +20,7 @@ defmodule Explorer.Counters.Helper do
   def fetch_from_cache(key, cache_name, default \\ 0) do
     case :ets.lookup(cache_name, key) do
       [{_, value}] ->
-        Logger.debug("Cache hit for #{key}")
+        Logger.debug("Cache hit for #{inspect(key)}")
         value
 
       [] ->

--- a/apps/explorer/lib/explorer/sorting_helper.ex
+++ b/apps/explorer/lib/explorer/sorting_helper.ex
@@ -9,7 +9,6 @@ defmodule Explorer.SortingHelper do
   specifies name of a key in paging_options and arbitrary dynamic that will be used in ordering and pagination,
   third entry specifies own column name to order by and paginate.
   """
-  require Explorer.SortingHelper
 
   alias Explorer.PagingOptions
 

--- a/docker-compose-pg.yml
+++ b/docker-compose-pg.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+name: "blockscout"
+
+services:
+  db:
+    image: postgres:15
+    shm_size: 256m
+    restart: always
+    container_name: "bsdb"
+    command: postgres -c 'max_connections=10000' -c 'client_connection_check_interval=60000'
+    environment:
+      POSTGRES_DB: "blockscout"
+      POSTGRES_USER: "blockscout"
+      POSTGRES_PASSWORD: "blockscout"
+    ports:
+      - "5432:5432"
+    # volumes:
+    #   - ./psql-volume:/var/lib/psql

--- a/docker-compose-pg.yml
+++ b/docker-compose-pg.yml
@@ -14,5 +14,3 @@ services:
       POSTGRES_PASSWORD: "blockscout"
     ports:
       - "5432:5432"
-    # volumes:
-    #   - ./psql-volume:/var/lib/psql


### PR DESCRIPTION
# Bug Fix

This PR fixes the following error: [GSD-4716](https://app.clickup.com/t/37444509/GSD-4716)
```exs
# Protocol.UndefinedError at GET /api/v2/addresses/0x15a128e599b74842BCcBa860311Efa92991bffb5/tabs-counters

Exception:

    ** (Protocol.UndefinedError) protocol String.Chars not implemented for {"0x15a128e599b74842bccba860311efa92991bffb5", :validations} of type Tuple. This protocol is implemented for the following type(s): Atom, BitString, Cldr.Currency, Cldr.LanguageTag, Cldr.LanguageTag.T, Cldr.LanguageTag.U, Cldr.Unit, Date, DateTime, Decimal, ExJsonSchema.Validator.Error.AdditionalItems, ExJsonSchema.Validator.Error.AdditionalProperties, ExJsonSchema.Validator.Error.AllOf, ExJsonSchema.Validator.Error.AnyOf, ExJsonSchema.Validator.Error.Const, ExJsonSchema.Validator.Error.Contains, ExJsonSchema.Validator.Error.ContentEncoding, ExJsonSchema.Validator.Error.ContentMediaType, ExJsonSchema.Validator.Error.Dependencies, ExJsonSchema.Validator.Error.Enum, ExJsonSchema.Validator.Error.False, ExJsonSchema.Validator.Error.Format, ExJsonSchema.Validator.Error.IfThenElse, ExJsonSchema.Validator.Error.ItemsNotAllowed, ExJsonSchema.Validator.Error.MaxItems, ExJsonSchema.Validator.Error.MaxLength, ExJsonSchema.Validator.Error.MaxProperties, ExJsonSchema.Validator.Error.Maximum, ExJsonSchema.Validator.Error.MinItems, ExJsonSchema.Validator.Error.MinLength, ExJsonSchema.Validator.Error.MinProperties, ExJsonSchema.Validator.Error.Minimum, ExJsonSchema.Validator.Error.MultipleOf, ExJsonSchema.Validator.Error.Not, ExJsonSchema.Validator.Error.OneOf, ExJsonSchema.Validator.Error.Pattern, ExJsonSchema.Validator.Error.PropertyNames, ExJsonSchema.Validator.Error.Required, ExJsonSchema.Validator.Error.Type, ExJsonSchema.Validator.Error.UniqueItems, Explorer.Chain.Address, Explorer.Chain.Data, Explorer.Chain.Hash, FileInfo.Mime, Float, Floki.Selector, Floki.Selector.AttributeSelector, Floki.Selector.Combinator, Floki.Selector.Functional, Floki.Selector.PseudoClass, Hex.Solver.Assignment, Hex.Solver.Constraints.Empty, Hex.Solver.Constraints.Range, Hex.Solver.Constraints.Union, Hex.Solver.Incompatibility, Hex.Solver.PackageRange, Hex.Solver.Term, Integer, List, NaiveDateTime, Postgrex.Copy, Postgrex.Query, Que.Job, RemoteIp.Block, Time, URI, Version, Version.Requirement
        (elixir 1.14.5) lib/string/chars.ex:3: String.Chars.impl_for!/1
        (elixir 1.14.5) lib/string/chars.ex:22: String.Chars.to_string/1
        (explorer 6.1.0) lib/explorer/counters/helper.ex:23: Explorer.Counters.Helper.fetch_from_cache/3
        (explorer 6.1.0) lib/explorer/chain/cache/addresses_tabs_counters.ex:19: Explorer.Chain.Cache.AddressesTabsCounters.get_counter/2
        (explorer 6.1.0) lib/explorer/chain/address/counters.ex:335: anonymous fn/3 in Explorer.Chain.Address.Counters.address_limited_counters/2
        (elixir 1.14.5) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
        (explorer 6.1.0) lib/explorer/chain/address/counters.ex:334: Explorer.Chain.Address.Counters.address_limited_counters/2
        (block_scout_web 6.1.0) lib/block_scout_web/controllers/api/v2/address_controller.ex:428: BlockScoutWeb.API.V2.AddressController.tabs_counters/2
```

## Reason
The `Logger.debug` method at line 20 of the file `apps/explorer/lib/explorer/counters/helper.ex` was trying to log what was the key that hit the cache lookup:
```ex
Logger.debug("Cache hit for #{key}")
```

The problem is that `key` was an tuple, which cannot, by itself, be used as string. This is why we were seeing the: `protocol String.Chars not implemented for {"0x15a128e599b74842bccba860311efa92991bffb5", :validations} of type Tuple.`

In order to fix it I just added the `inspect/2` method, which try to represent the variable passed to it as a string. This was the result:
```ex
Logger.debug("Cache hit for #{inspect(key)}")
# Then in logs we'll get:
# [debug] Cache hit for {"0x15a128e599b74842bccba860311efa92991bffb5", :validations}
```